### PR TITLE
feat: 640px 이상 기기에서 표현할 플레이스홀더 ui 구현

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,24 +1,52 @@
+import { Icons } from "@team-numberone/daepiro-design-system";
 import type { Metadata } from "next";
-import "./globals.css";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
+import "./globals.css";
 
 export const metadata: Metadata = {
 	title: "119-web-client",
 	description: "대피로 디자인 시스템 + Tailwind CSS v4",
 };
 
+function MobileOnly({ children }: { children: React.ReactNode }) {
+	return <div className="block sm:hidden">{children}</div>;
+}
+
+function DesktopOnly({ children }: { children: React.ReactNode }) {
+	return <div className="hidden sm:block">{children}</div>;
+}
+
+function DesktopPlaceholder() {
+	return (
+		<div className="w-full h-screen flex justify-center items-center flex-col gap-3">
+			<Icons.Warning color="var(--color-gray-300)" size={42} />
+			<div className="text-center text-gray-600 text-h6">
+				해당 서비스는 <br />
+				모바일 환경에 맞춰 제작되었습니다.
+			</div>
+		</div>
+	);
+}
+
 export default function RootLayout({
 	children,
-}: Readonly<{
+}: {
 	children: React.ReactNode;
-}>) {
+}) {
 	return (
 		<html lang="ko">
 			<body className="min-h-screen bg-gray-50">
 				<Header />
-				{children}
-				<Footer />
+
+				<MobileOnly>
+					{children}
+					<Footer />
+				</MobileOnly>
+
+				<DesktopOnly>
+					<DesktopPlaceholder />
+				</DesktopOnly>
 			</body>
 		</html>
 	);


### PR DESCRIPTION
## 📝 변경 사항

- 640px 이상 화면에서 모바일 전용 플레이스홀더 UI 표시
- `layout.tsx`에서 CSS 미디어 쿼리로 모바일/데스크톱 레이아웃 분리
- 모든 페이지에 자동 적용

## 🎯 작업 목적

640px 이상의 데스크톱 화면에서 접속한 사용자에게 모바일 전용 서비스임을 명확히 안내하여 사용자 경험을 개선합니다.

## 🔍 변경 내용 상세

- [x] `layout.tsx`에 모바일/데스크톱 레이아웃 분리 로직 추가
- [x] `DesktopPlaceholder` 컴포넌트 구현 (경고 아이콘 + 안내 메시지)
- [x] CSS 미디어 쿼리 기반 조건부 렌더링 적용 (깜빡임 방지)
- [x] 모든 페이지에 자동 적용되도록 레이아웃 레벨에서 처리

## 📸 스크린샷 (선택사항)

<img width="379" height="670" alt="image" src="https://github.com/user-attachments/assets/75aa39f2-2401-47c9-956d-4863a2a626d4" />
<img width="1279" height="933" alt="image" src="https://github.com/user-attachments/assets/b26530bd-7d6e-4b3d-85ac-a7c780667aad" />

<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트

- [x] 코드 스타일이 프로젝트 가이드라인을 따릅니다
- [x] 자체 검토를 완료했습니다
- [x] 주석을 추가했으며, 특히 이해하기 어려운 부분에 주석을 달았습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] 변경 사항이 새로운 경고를 생성하지 않습니다
- [x] 테스트를 추가했으며, 기존 테스트를 통과합니다 (필요한 경우)
- [x] 의존성 변경이 있다면 `package.json`을 업데이트했습니다

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 링크해주세요 -->
Closes #2 

## 💬 리뷰어에게 전달할 사항

<!-- 리뷰어가 특별히 확인해야 할 부분이나 질문이 있다면 작성해주세요 -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated app layout with device-specific rendering. Mobile displays full app content and footer as usual. Desktop now shows a placeholder with a warning message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->