### PR TITLE
[FEATURE] 상황 연습 ui 구현

### DIFF
--- a/app/components/EmergencySituationCarousel.tsx
+++ b/app/components/EmergencySituationCarousel.tsx
@@ -1,30 +1,52 @@
 "use client";
 
 import { Icons } from "@team-numberone/daepiro-design-system";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { CarouselItem } from "../constants/practiceItems";
 
 interface EmergencySituationCarouselProps {
 	items: CarouselItem[];
+	onSelect?: (situationId: string) => void;
 }
 
 export function EmergencySituationCarousel({
 	items,
+	onSelect,
 }: EmergencySituationCarouselProps) {
 	const [currentIndex, setCurrentIndex] = useState(0);
+
+	const currentItem = items?.[currentIndex];
+
+	// 초기 선택된 항목을 상위로 전달 (훅은 early return 전에 호출되어야 함)
+	useEffect(() => {
+		if (currentItem && onSelect) {
+			onSelect(currentItem.id);
+		}
+	}, [currentItem, onSelect]);
 
 	// 안전장치: items가 비어있으면 렌더링 X
 	if (!items || items.length === 0) return null;
 
 	const handlePrevious = () => {
-		setCurrentIndex((prev) => (prev === 0 ? items.length - 1 : prev - 1));
+		setCurrentIndex((prev) => {
+			const newIndex = prev === 0 ? items.length - 1 : prev - 1;
+			onSelect?.(items[newIndex].id);
+			return newIndex;
+		});
 	};
 
 	const handleNext = () => {
-		setCurrentIndex((prev) => (prev === items.length - 1 ? 0 : prev + 1));
+		setCurrentIndex((prev) => {
+			const newIndex = prev === items.length - 1 ? 0 : prev + 1;
+			onSelect?.(items[newIndex].id);
+			return newIndex;
+		});
 	};
 
-	const currentItem = items[currentIndex];
+	const handleDotClick = (index: number) => {
+		setCurrentIndex(index);
+		onSelect?.(items[index].id);
+	};
 
 	return (
 		<div className="w-full flex flex-col flex-1 min-h-0">
@@ -77,7 +99,7 @@ export function EmergencySituationCarousel({
 					<button
 						key={item.id}
 						type="button"
-						onClick={() => setCurrentIndex(index)}
+						onClick={() => handleDotClick(index)}
 						className={`w-[6px] h-[6px] rounded-full ${
 							index === currentIndex ? "bg-gray-500" : "bg-gray-100"
 						}`}

--- a/app/components/StartPracticeButton.tsx
+++ b/app/components/StartPracticeButton.tsx
@@ -1,9 +1,26 @@
-import { Button } from "@team-numberone/daepiro-design-system";
+"use client";
 
-export function StartPracticeButton() {
+import { Button } from "@team-numberone/daepiro-design-system";
+import { useRouter } from "next/navigation";
+
+interface StartPracticeButtonProps {
+	situationId: string;
+}
+
+export function StartPracticeButton({ situationId }: StartPracticeButtonProps) {
+	const router = useRouter();
+
+	const handleClick = () => {
+		router.push(`/practice/${situationId}`);
+	};
+
 	return (
 		<div className="w-full px-[20px] shrink-0 pb-[clamp(12px,2svh,20px)] flex justify-center items-center">
-			<Button variant="primary" className="w-full max-w-[280px]">
+			<Button
+				variant="primary"
+				className="w-full max-w-[280px]"
+				onClick={handleClick}
+			>
 				시작하기
 			</Button>
 		</div>

--- a/app/constants/detailSituations.ts
+++ b/app/constants/detailSituations.ts
@@ -1,0 +1,46 @@
+export interface DetailSituation {
+	id: string;
+	location: string; // "멀리 난", "제 앞에" 등
+	description: string; // "불을 봤어요", "불이 났어요" 등
+}
+
+export type SituationId =
+	| "fire"
+	| "drowning"
+	| "emergency"
+	| "traffic"
+	| "other";
+
+export const detailSituations: Record<SituationId, DetailSituation[]> = {
+	fire: [
+		{ id: "fire-far", location: "멀리 난", description: "불을 봤어요" },
+		{ id: "fire-near", location: "제 앞에", description: "불이 났어요" },
+	],
+	drowning: [
+		{
+			id: "drowning-other",
+			location: "다른 사람이",
+			description: "물에 빠졌어요",
+		},
+		{ id: "drowning-me", location: "제가", description: "물에 빠졌어요" },
+	],
+	emergency: [
+		{
+			id: "emergency-conscious",
+			location: "의식이",
+			description: "있는 환자예요",
+		},
+		{
+			id: "emergency-unconscious",
+			location: "의식이",
+			description: "없는 환자예요",
+		},
+	],
+	traffic: [
+		{ id: "traffic-minor", location: "경미한", description: "교통사고예요" },
+		{ id: "traffic-severe", location: "심각한", description: "교통사고예요" },
+	],
+	other: [
+		{ id: "other-specified", location: "기타", description: "응급상황이에요" },
+	],
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { EmergencySituationCarousel } from "./components/EmergencySituationCarousel";
 import { PracticeSectionHeader } from "./components/PracticeSectionHeader";
 import { RandomPracticeCTA } from "./components/RandomPracticeCTA";
@@ -5,6 +8,10 @@ import { StartPracticeButton } from "./components/StartPracticeButton";
 import { practiceItems } from "./constants/practiceItems";
 
 export default function HomePage() {
+	const [selectedSituationId, setSelectedSituationId] = useState<string>(
+		practiceItems[0]?.id || "",
+	);
+
 	return (
 		<div className="h-full overflow-hidden flex flex-col">
 			{/* 그라디언트 섹션 */}
@@ -13,10 +20,13 @@ export default function HomePage() {
 
 				{/* 캐러셀: 남는 세로 공간 먹기 */}
 				<div className="flex-1 min-h-0 flex">
-					<EmergencySituationCarousel items={practiceItems} />
+					<EmergencySituationCarousel
+						items={practiceItems}
+						onSelect={setSelectedSituationId}
+					/>
 				</div>
 
-				<StartPracticeButton />
+				<StartPracticeButton situationId={selectedSituationId} />
 			</div>
 
 			<RandomPracticeCTA />

--- a/app/practice/[situationId]/components/DetailSituationCard.tsx
+++ b/app/practice/[situationId]/components/DetailSituationCard.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Icons } from "@team-numberone/daepiro-design-system";
+import type { DetailSituation } from "../../../constants/detailSituations";
+
+interface DetailSituationCardProps {
+	situation: DetailSituation;
+	onClick?: () => void;
+}
+
+export function DetailSituationCard({
+	situation,
+	onClick,
+}: DetailSituationCardProps) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className="w-full max-w-[320px] bg-white rounded-[20px] pt-6 pr-[14px] pb-[14px] pl-6 flex flex-col justify-center items-end gap-3 border-2 border-[#EEEFF2]"
+		>
+			<div className="text-left w-full">
+				<div className="text-primary-400 text-h5">{situation.location}</div>
+				<div className="text-gray-700 text-h5">{situation.description}</div>
+			</div>
+			<Icons.Start
+				size={32}
+				color="var(--color-gray-300)"
+				className="shrink-0"
+			/>
+		</button>
+	);
+}

--- a/app/practice/[situationId]/components/DetailSituationList.tsx
+++ b/app/practice/[situationId]/components/DetailSituationList.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { DetailSituation } from "../../../constants/detailSituations";
+import { DetailSituationCard } from "./DetailSituationCard";
+
+interface DetailSituationListProps {
+	situationId: string;
+	situations: DetailSituation[];
+}
+
+export function DetailSituationList({
+	situationId,
+	situations,
+}: DetailSituationListProps) {
+	const handleCardClick = (detailId: string) => {
+		// TODO: 다음 단계로 이동하는 로직 구현
+		console.log(`Selected: ${situationId} - ${detailId}`);
+	};
+
+	return (
+		<div className="flex-1 min-h-0 overflow-y-auto pt-8 px-5 pb-4">
+			<div className="flex flex-col gap-3 items-center">
+				{situations.map((situation) => (
+					<DetailSituationCard
+						key={situation.id}
+						situation={situation}
+						onClick={() => handleCardClick(situation.id)}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/app/practice/[situationId]/components/DetailSituationTitle.tsx
+++ b/app/practice/[situationId]/components/DetailSituationTitle.tsx
@@ -1,0 +1,12 @@
+export function DetailSituationTitle() {
+	return (
+		<div className="w-full pt-[clamp(56px,10svh,72px)] shrink-0">
+			<div className="flex items-center justify-between w-full flex-col pt-3">
+				<div className="text-gray-400 text-body-1 mb-1">세부 상황 선택</div>
+				<div className="text-gray-700 text-[26px] leading-[32px] font-bold">
+					어떤 상황이야?
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/practice/[situationId]/page.tsx
+++ b/app/practice/[situationId]/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+import {
+	detailSituations,
+	type SituationId,
+} from "@/app/constants/detailSituations";
+import { DetailSituationList } from "@/app/practice/[situationId]/components/DetailSituationList";
+import { DetailSituationTitle } from "@/app/practice/[situationId]/components/DetailSituationTitle";
+
+interface DetailSituationPageProps {
+	params: Promise<{ situationId: string }>;
+}
+
+export default async function DetailSituationPage({
+	params,
+}: DetailSituationPageProps) {
+	const { situationId } = await params;
+
+	// 유효한 situationId인지 확인
+	if (!(situationId in detailSituations)) {
+		notFound();
+	}
+
+	const situations = detailSituations[situationId as SituationId];
+
+	return (
+		<div className="h-full overflow-hidden flex flex-col bg-gray-50">
+			<DetailSituationTitle />
+
+			{/* 세부 상황 리스트 (스크롤 가능) */}
+			<DetailSituationList situationId={situationId} situations={situations} />
+		</div>
+	);
+}


### PR DESCRIPTION
## 📝 변경 사항

상황 연습 페이지의 세부 상황 선택 UI를 구현하고, 메인 페이지와 연결했습니다.

## 🎯 작업 목적

- 메인 페이지에서 선택한 응급 상황의 세부 상황을 선택할 수 있는 페이지 구현
- 단계별 UI 플로우를 통한 직관적인 사용자 경험 제공
- 메인 페이지와 세부 상황 선택 페이지 간 네비게이션 연결

## 🔍 변경 내용 상세

- [x] 세부 상황 선택 페이지 구현 (`app/practice/[situationId]/page.tsx`)

  - 동적 라우팅을 통한 상황별 페이지 생성 (`/practice/fire`, `/practice/drowning` 등)
  - 유효하지 않은 `situationId`에 대한 404 처리

- [x] 세부 상황 선택 UI 컴포넌트 구현

  - `DetailSituationTitle`: "세부 상황 선택" 헤더 컴포넌트
  - `DetailSituationCard`: 개별 세부 상황 카드 컴포넌트 (위치, 설명, 시작 아이콘)
  - `DetailSituationList`: 세부 상황 리스트 컴포넌트

- [x] 메인 페이지와 세부 상황 선택 페이지 연결

  - `EmergencySituationCarousel`: 선택된 상황 ID를 상위로 전달하는 `onSelect` prop 추가
  - `StartPracticeButton`: 선택된 상황 ID를 받아 해당 세부 상황 선택 페이지로 라우팅
  - `page.tsx`: 클라이언트 컴포넌트로 변경하여 선택된 상황 ID 상태 관리

## 📸 스크린샷 (선택사항)

<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
<img width="386" height="678" alt="image" src="https://github.com/user-attachments/assets/e562d5c8-6ad6-4212-ab92-77e3873bfcfd" />


## ✅ 체크리스트

- [x] 코드 스타일이 프로젝트 가이드라인을 따릅니다
- [x] 자체 검토를 완료했습니다
- [x] 주석을 추가했으며, 특히 이해하기 어려운 부분에 주석을 달았습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] 변경 사항이 새로운 경고를 생성하지 않습니다
- [ ] 테스트를 추가했으며, 기존 테스트를 통과합니다 (필요한 경우)
- [x] 의존성 변경이 있다면 `package.json`을 업데이트했습니다

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 링크해주세요 -->

Closes #5 
